### PR TITLE
Feat/mypage and logout

### DIFF
--- a/branch/build.gradle
+++ b/branch/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //aws s3
+    implementation 'software.amazon.awssdk:s3:2.17.58'
+
 	//redis 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -49,7 +52,7 @@ dependencies {
 	//websocket 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
-	//    eureka client의존성 추가
+	//eureka client의존성 추가
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	//feign 클라이언트

--- a/branch/build.gradle
+++ b/branch/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     //aws s3
     implementation 'software.amazon.awssdk:s3:2.17.58'
 
+    //spring mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	//redis 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/branch/src/main/java/com/careup/branch/common/auth/JwtProperties.java
+++ b/branch/src/main/java/com/careup/branch/common/auth/JwtProperties.java
@@ -16,20 +16,20 @@ public class JwtProperties {
 
     /// 위에 적은 accessTokenExpiryMinutes 값을 코드에서 읽을 때 사용
     public int getAccessTokenExpiryMinutes()
-        { return accessTokenExpiryMinutes; }
+    { return accessTokenExpiryMinutes; }
     /// 스프링이 yml에 적힌 값을 여기에 넣어줄 때 사용
     public void setAccessTokenExpiryMinutes(int accessTokenExpiryMinutes)
-        { this.accessTokenExpiryMinutes = accessTokenExpiryMinutes; }
+    { this.accessTokenExpiryMinutes = accessTokenExpiryMinutes; }
 
     public int getRefreshTokenExpiryDaysPersistent()
-        { return refreshTokenExpiryDaysPersistent; }
+    { return refreshTokenExpiryDaysPersistent; }
     public void setRefreshTokenExpiryDaysPersistent(int refreshTokenExpiryDaysPersistent)
-        { this.refreshTokenExpiryDaysPersistent = refreshTokenExpiryDaysPersistent; }
+    { this.refreshTokenExpiryDaysPersistent = refreshTokenExpiryDaysPersistent; }
 
     public int getRefreshTokenExpiryDaysNonPersistent()
-        { return refreshTokenExpiryDaysNonPersistent; }
+    { return refreshTokenExpiryDaysNonPersistent; }
     public void setRefreshTokenExpiryDaysNonPersistent(int refreshTokenExpiryDaysNonPersistent)
-        { this.refreshTokenExpiryDaysNonPersistent = refreshTokenExpiryDaysNonPersistent; }
+    { this.refreshTokenExpiryDaysNonPersistent = refreshTokenExpiryDaysNonPersistent; }
 
     /// AT 서명 비밀키(Base64)를 코드에서 읽을 때 사용
     public String getSecretKeyAt() { return secretKeyAt; }

--- a/branch/src/main/java/com/careup/branch/common/auth/JwtTokenFilter.java
+++ b/branch/src/main/java/com/careup/branch/common/auth/JwtTokenFilter.java
@@ -49,7 +49,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 String role = String.valueOf(c.get("role"));
                 var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
-                /// 6) 인증 객체 생성(Principal: subject=loginId)
+                /// 6) 인증 객체 생성(Principal: subject=employeeId 문자열)
                 var auth = new UsernamePasswordAuthenticationToken(c.getSubject(), null, authorities);
 
                 /// 7) 필요 시 세부정보로 Claims를 담아 컨트롤러에서 활용 가능

--- a/branch/src/main/java/com/careup/branch/common/auth/JwtTokenProvider.java
+++ b/branch/src/main/java/com/careup/branch/common/auth/JwtTokenProvider.java
@@ -1,19 +1,15 @@
 package com.careup.branch.common.auth;
 
-/// JWT를 만들고 파싱(검증)할 때 필요
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-
-/// 스프링 컴포넌트와 초기화 훅
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-/// 시크릿(Base64) → 바이트 변환, 만료시간 계산에 사용
 import java.security.Key;
 import java.time.Duration;
 import java.util.Base64;
@@ -21,111 +17,97 @@ import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
-    /// yml에서 읽어온 설정값 묶음(앞에서 만든 JwtProperties)
+
     private final JwtProperties props;
-
-    /// RT를 저장/검증하기 위한 Redis. (opsForValue().get/set 사용)
-    private final RedisTemplate<String, String> redisTemplate;
-
-    /// 서명에 실제로 쓰이는 Key 객체(AT/RT 각각 따로)
+    private final RedisTemplate<String, String> redis;
     private Key atKey;
     private Key rtKey;
 
-    /// 생성자: 스프링이 JwtProperties/RedisTemplate을 자동 주입
     public JwtTokenProvider(JwtProperties props,
-                            @Qualifier("rtInventory") RedisTemplate<String, String> redisTemplate) {
+                            @Qualifier("rtInventory") RedisTemplate<String, String> redis) {
         this.props = props;
-        this.redisTemplate = redisTemplate;
+        this.redis = redis;
     }
 
-    /// @PostConstruct: 스프링이 이 컴포넌트를 생성한 후 1회 호출
-    /// 여기서 Base64 문자열을 "실제 키 바이트"로 변환
     @PostConstruct
     public void init() {
-        /// *** Base64 → 바이트 → HS512용 HMAC 키로 변환 ***
         byte[] atBytes = Base64.getDecoder().decode(props.getSecretKeyAt());
         byte[] rtBytes = Base64.getDecoder().decode(props.getSecretKeyRt());
-
-        /// HS512는 64바이트(=512비트) 이상 권장
         if (atBytes.length < 64) throw new IllegalArgumentException("HS512용 AT 키는 64바이트 이상이어야 합니다.");
         if (rtBytes.length < 64) throw new IllegalArgumentException("HS512용 RT 키는 64바이트 이상이어야 합니다.");
-
-        /// 바이트 배열을 JWT 라이브러리가 이해하는 Key 객체로 변경
         this.atKey = Keys.hmacShaKeyFor(atBytes);
         this.rtKey = Keys.hmacShaKeyFor(rtBytes);
     }
 
-    /// 로그인 성공 시, 짧게 들고 다닐 Access Token(AT)을 생성
-    /// - subject: 로그인ID(예: loginId)
-    /// - role/employeeId 같은 정보는 "클레임"으로 넣어 둠
-    public String createAccessToken(String loginId, String role, Long employeeId) {
-        /// 현재 시간(now)와 만료시간(ms)을 계산
+    private static String rtKey(Long employeeId) {
+        return "RT:EMP:" + employeeId;
+    }
+
+    /** subject = employeeId 문자열 */
+    public String createAccessToken(Long employeeId, String role) {
         Date now = new Date();
         long atMillis = Duration.ofMinutes(props.getAccessTokenExpiryMinutes()).toMillis();
 
-        /// 토큰 안에 들어갈 내용(payload)을 구성(클레임)
-        Claims claims = Jwts.claims().setSubject(loginId);
+        Claims claims = Jwts.claims().setSubject(String.valueOf(employeeId));
         claims.put("role", role);
-        if (employeeId != null) claims.put("employeeId", employeeId);
+        claims.put("employeeId", employeeId);
 
-        /// HS512로 서명해서 최종 문자열(JWT)로 만들어 반환
         return Jwts.builder()
-                .setClaims(claims)                                  /// 내용
-                .setIssuedAt(now)                                   /// 발급시각
-                .setExpiration(new Date(now.getTime() + atMillis))  /// 만료시각
-                .signWith(atKey, SignatureAlgorithm.HS512)          /// 여기서 "서명(signature)" 발생
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + atMillis))
+                .signWith(atKey, SignatureAlgorithm.HS512)
                 .compact();
     }
 
-    /// 자동로그인(rememberMe)에 따라 만료일이 다른 Refresh Token을 만들어 저장(서버 기억)
-    /// - rememberMe가 true면 오래(예: 180일), false면 짧게(예: 1일)
-    public String createRefreshToken(String loginId, boolean rememberMe) {
+    /** rememberMe=false면 RT 미발급(null 반환). rememberMe=true면 단일 슬롯 저장 */
+    public String createRefreshToken(Long employeeId, boolean rememberMe) {
+        if (!rememberMe) return null; // ★ 핵심
+
         Date now = new Date();
-        int days = rememberMe ? props.getRefreshTokenExpiryDaysPersistent()
-                : props.getRefreshTokenExpiryDaysNonPersistent();
+        int days = props.getRefreshTokenExpiryDaysPersistent(); // 자동 로그인 전용 만료
         long rtMillis = Duration.ofDays(days).toMillis();
 
-        /// RT는 보통 간단한 정보만 담고, 서버(Redis)에 저장해 재발급 시 대조
-        Claims claims = Jwts.claims().setSubject(loginId);
+        Claims claims = Jwts.claims().setSubject(String.valueOf(employeeId));
 
         String rt = Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + rtMillis))
-                .signWith(rtKey, SignatureAlgorithm.HS512) // RT도 HS512로 서명
+                .signWith(rtKey, SignatureAlgorithm.HS512)
                 .compact();
 
-        /// Redis에 "RT:{loginId}" 라는 키로 저장 (유효기간과 동일하게 TTL 지정)
-        redisTemplate.opsForValue().set("RT:" + loginId, rt, Duration.ofMillis(rtMillis));
+        // 계정 당 단일 슬롯
+        redis.opsForValue().set(rtKey(employeeId), rt, Duration.ofMillis(rtMillis));
         return rt;
     }
 
-    /// 클라이언트가 보낸 AT가 "정상적으로 서명되고, 아직 안 만료됐는지" 검증하고
-    /// 유효하면 안의 내용(클레임)을 꺼내 반환
     public Claims parseAccessToken(String token) {
-        /// 서명이 틀리거나 만료되면 예외 처리 (401)
         return Jwts.parserBuilder()
-                .setSigningKey(atKey)      /// AT 서명 키로 검증
+                .setSigningKey(atKey)
                 .build()
-                .parseClaimsJws(token)     /// 검증+파싱
-                .getBody();                /// payload(클레임) 반환
+                .parseClaimsJws(token)
+                .getBody();
     }
 
-    /// RT가 유효한지 검증한 후, 서버(Redis)에 저장된 것과 "정확히 같은지" 확인
+    /** RT 서명/만료 검증 + Redis 저장 RT 일치 확인 */
     public Claims validateRefreshToken(String refreshToken) {
-        /// 1) 서명/만료 검증
         Claims claims = Jwts.parserBuilder()
-                .setSigningKey(rtKey)      // RT 서명 키로 검증
+                .setSigningKey(rtKey)
                 .build()
                 .parseClaimsJws(refreshToken)
                 .getBody();
 
-        /// 2) 서버 저장값과 일치하는지 확인(탈취/로그아웃 등 통제 가능)
-        String loginId = claims.getSubject();
-        String saved = redisTemplate.opsForValue().get("RT:" + loginId);
+        Long employeeId = Long.valueOf(claims.getSubject());
+        String saved = redis.opsForValue().get(rtKey(employeeId));
         if (saved == null || !saved.equals(refreshToken)) {
             throw new JwtException("유효하지 않은 토큰입니다.");
         }
         return claims;
+    }
+
+    /** 로그아웃(계정 단위) */
+    public void revokeRefreshToken(Long employeeId) {
+        redis.delete(rtKey(employeeId));
     }
 }

--- a/branch/src/main/java/com/careup/branch/common/auth/PasswordResetTokenStore.java
+++ b/branch/src/main/java/com/careup/branch/common/auth/PasswordResetTokenStore.java
@@ -1,0 +1,45 @@
+package com.careup.branch.common.auth;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
+
+@Component
+public class PasswordResetTokenStore {
+
+    private static final Duration TTL = Duration.ofMinutes(15);
+    private final RedisTemplate<String, String> redis;
+
+    public PasswordResetTokenStore(@Qualifier("rtInventory") RedisTemplate<String, String> redis) {
+        this.redis = redis;
+    }
+
+    private static String key(String email) {
+        return "BRANCH:PWRESET:" + email;
+    }
+
+    public String issue(String email) {
+        String token = generateToken();
+        redis.opsForValue().set(key(email), token, TTL);
+        return token;
+    }
+
+    public Optional<String> get(String email) {
+        return Optional.ofNullable(redis.opsForValue().get(key(email)));
+    }
+
+    public void delete(String email) {
+        redis.delete(key(email));
+    }
+
+    private static String generateToken() {
+        byte[] buf = new byte[18];
+        new SecureRandom().nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+}

--- a/branch/src/main/java/com/careup/branch/common/config/AwsS3Config.java
+++ b/branch/src/main/java/com/careup/branch/common/config/AwsS3Config.java
@@ -1,0 +1,49 @@
+package com.careup.branch.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static:${cloud.aws.region:ap-northeast-2}}")
+    private String region;
+
+    private AwsCredentialsProvider credentialsProvider() {
+        if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+        return DefaultCredentialsProvider.create();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+}

--- a/branch/src/main/java/com/careup/branch/common/config/SecurityConfig.java
+++ b/branch/src/main/java/com/careup/branch/common/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
         /// 2) URL 접근 권한 설정
         http.authorizeHttpRequests(auth -> auth
                 /// 로그인 없이 접근 가능한 공개 경로들
-                .requestMatchers("/actuator/**", "/auth/**", "/public/**").permitAll()
+                .requestMatchers("/actuator/**", "/auth/**", "/public/**", "/health").permitAll()
                 /// 그 외 모든 경로는 인증(토큰) 필요
                 .anyRequest().authenticated()
         );

--- a/branch/src/main/java/com/careup/branch/common/exception/FileHandlingException.java
+++ b/branch/src/main/java/com/careup/branch/common/exception/FileHandlingException.java
@@ -1,0 +1,7 @@
+package com.careup.branch.common.exception;
+
+public class FileHandlingException extends RuntimeException {
+    public FileHandlingException(String message) {
+        super(message);
+    }
+}

--- a/branch/src/main/java/com/careup/branch/common/file/AwsS3Uploader.java
+++ b/branch/src/main/java/com/careup/branch/common/file/AwsS3Uploader.java
@@ -1,0 +1,193 @@
+package com.careup.branch.common.file;
+
+import com.careup.branch.common.exception.FileHandlingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Uploader {
+
+    private static final String PATH_IMAGE = "image";
+    private static final String PATH_AUDIO = "audio";
+    private static final String PATH_DOCUMENT = "document";
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static:${cloud.aws.region:ap-northeast-2}}")
+    private String region;
+
+    public String uploadFile(final String tableName, final Long objectSeq, final MultipartFile multipartFile) {
+        try {
+            final String contentType = multipartFile.getContentType();
+            final String originalFilename = multipartFile.getOriginalFilename();
+            final String key = createFilePath(contentType, tableName, objectSeq, originalFilename);
+
+            final PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(req, RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize()));
+            final String url = s3Client.utilities().getUrl(a -> a.bucket(bucket).key(key)).toExternalForm();
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (FileHandlingException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("S3 업로드 실패", e);
+            throw new FileHandlingException("s3 파일 업로드에 실패했습니다.");
+        }
+    }
+
+    public String uploadFile(final String tableName,
+                             final Long objectSeq,
+                             final InputStream inputStream,
+                             final long contentLength,
+                             final String contentType,
+                             final String originalFilename) {
+        try {
+            final String key = createFilePath(contentType, tableName, objectSeq, originalFilename);
+
+            final PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(req, RequestBody.fromInputStream(inputStream, contentLength));
+            final String url = s3Client.utilities().getUrl(a -> a.bucket(bucket).key(key)).toExternalForm();
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (FileHandlingException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("S3 업로드 실패(InputStream)", e);
+            throw new FileHandlingException("s3 파일 업로드에 실패했습니다.");
+        }
+    }
+
+    public String generatePresignedUrl(final String fileUrl) {
+        return generatePresignedUrl(fileUrl, Duration.ofMinutes(1));
+    }
+
+    public String generatePresignedUrl(final String fileUrl, final Duration ttl) {
+        if (fileUrl == null || fileUrl.isBlank()) return null;
+        try {
+            final String key = toS3Key(fileUrl);
+
+            final GetObjectRequest get = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            final GetObjectPresignRequest presign = GetObjectPresignRequest.builder()
+                    .signatureDuration(ttl)
+                    .getObjectRequest(get)
+                    .build();
+
+            final PresignedGetObjectRequest p = s3Presigner.presignGetObject(presign);
+            return p.url().toExternalForm();
+        } catch (Exception e) {
+            log.error("S3 pre-signed URL 생성 실패: {}", fileUrl, e);
+            return null;
+        }
+    }
+
+    public boolean existsByUrl(final String fileUrl) {
+        try {
+            final String key = toS3Key(fileUrl);
+            s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            log.error("S3 존재 여부 확인 실패: {}", fileUrl, e);
+            return false;
+        }
+    }
+
+    public void deleteByUrl(final String fileUrl) {
+        try {
+            final String key = toS3Key(fileUrl);
+            deleteByKey(key);
+        } catch (FileHandlingException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패: {}", fileUrl, e);
+            throw new FileHandlingException("s3 파일 삭제에 실패했습니다.");
+        }
+    }
+
+    public void deleteByKey(final String key) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패(key): {}", key, e);
+            throw new FileHandlingException("s3 파일 삭제에 실패했습니다.");
+        }
+    }
+
+    public String toS3Key(final String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            throw new FileHandlingException("S3 URL 형식이 올바르지 않습니다.");
+        }
+        final String decoded = URLDecoder.decode(fileUrl, StandardCharsets.UTF_8);
+        final String vh = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+        final String pathStyle = "https://s3." + region + ".amazonaws.com/" + bucket + "/";
+
+        if (decoded.startsWith(vh)) return decoded.substring(vh.length());
+        if (decoded.startsWith(pathStyle)) return decoded.substring(pathStyle.length());
+
+        log.error("S3 URL 형식이 올바르지 않습니다. fileUrl={}", fileUrl);
+        throw new FileHandlingException("S3 URL 형식이 올바르지 않습니다.");
+    }
+
+    private String createFilePath(final String contentType,
+                                  final String tableName,
+                                  final Long objectSeq,
+                                  final String originalFilename) {
+        if (contentType == null || originalFilename == null) {
+            throw new FileHandlingException("파일 메타정보가 누락되었습니다.");
+        }
+        final String lowerCt = contentType.toLowerCase(Locale.ROOT);
+        final String folder =
+                lowerCt.startsWith("image/") ? PATH_IMAGE :
+                        lowerCt.startsWith("audio/") ? PATH_AUDIO :
+                                lowerCt.equals("application/pdf") ? PATH_DOCUMENT :
+                                        null;
+
+        if (folder == null) {
+            log.error("지원하지 않는 Content-Type: {}", contentType);
+            throw new FileHandlingException(contentType + "은(는) 지원하지 않는 파일 형식입니다.");
+        }
+
+        final String safeName = originalFilename.replaceAll("[\\r\\n]", "");
+        return String.format("%s/%s/%d/%s_%s", folder, tableName, objectSeq, UUID.randomUUID(), safeName);
+    }
+}

--- a/branch/src/main/java/com/careup/branch/common/init/DataInitializer.java
+++ b/branch/src/main/java/com/careup/branch/common/init/DataInitializer.java
@@ -80,7 +80,7 @@ public class DataInitializer implements CommandLineRunner {
             ));
 
             createEmployee(
-                    "H2025001", "이승지", "hq.admin@starbucks.co.kr", "010-2331-4132", Gender.FEMALE,
+                    "H2025001", "이승지", "dev.s3lim@gmail.com", "010-2331-4132", Gender.FEMALE,
                     gradeIds.get("본사매니저"),
                     AuthorityType.HQ_ADMIN, EmploymentStatus.ACTIVE, EmploymentType.FULL_TIME,
                     "서울특별시 광진구 아차산로 200", "1203호", "05010",

--- a/branch/src/main/java/com/careup/branch/common/init/DataInitializer.java
+++ b/branch/src/main/java/com/careup/branch/common/init/DataInitializer.java
@@ -1,6 +1,6 @@
 package com.careup.branch.common.init;
 
-import com.careup.branch.domain.branch.dto.BranchRegisterReqDto;
+import com.careup.branch.domain.branch.dto.branch.BranchRegisterReqDto;
 import com.careup.branch.domain.branch.entity.Branch;
 import com.careup.branch.domain.branch.entity.OwnershipType;
 import com.careup.branch.domain.branch.repository.BranchRepository;
@@ -46,36 +46,39 @@ public class DataInitializer implements CommandLineRunner {
     private final JobGradeService jobGradeService;
     private final JobGradeRepository jobGradeRepository;
 
+    private static final String DEFAULT_PROFILE_URL =
+            "https://beyond-16-care-up.s3.ap-northeast-2.amazonaws.com/image/employee/profile/default/default_user.png";
+
     @Override
     @Transactional
     public void run(String... args) {
-        Long hqId = ensureBranch(
-                "본점", OwnershipType.NO, "101-10-00001", "110101-1000001",
-                "서울특별시 중구 을지로 100", "본관 15층",
-                "02-1577-0001", "hq@careup.com",
-                "본사/관리", LocalDate.now().minusYears(8),
-                "37.5665,126.9780", 400, "중앙 관제/정산 총괄"
-        );
-        Long dongjakId = ensureBranch(
-                "동작점", OwnershipType.NO, "102-20-00002", "220202-2000002",
-                "서울특별시 동작구 상도로 12길 7", "1층",
-                "02-826-0202", "dongjak@careup.com",
-                "카페/음료", LocalDate.now().minusYears(4),
-                "37.5124,126.9399", 300, "대학가 상권 중심, 테이크아웃 강세"
-        );
-        Long boramaeId = ensureBranch(
-                "보라매점", OwnershipType.YES, "103-30-00003", "330303-3000003",
-                "서울특별시 동작구 보라매로5가길 21", "A동 102호",
-                "02-834-0303", "boramae@careup.com",
-                "카페/디저트", LocalDate.now().minusYears(2),
-                "37.4924,126.9237", 250, "공원 상권, 주말 패밀리 비중 높음"
-        );
-
-        Map<String, Long> gradeIds = ensureJobGradesInTable(List.of(
-                "바리스타", "시프트 슈퍼바이저", "부점장", "점장", "지역매니저", "본사매니저"
-        ));
-
         runAsSystem(() -> {
+            Long hqId = ensureBranch(
+                    "본점", OwnershipType.NO, "101-10-00001", "110101-1000001",
+                    "서울특별시 중구 을지로 100", "본관 15층",
+                    "02-1577-0001", "hq@careup.com",
+                    "본사/관리", LocalDate.now().minusYears(8),
+                    "37.5665,126.9780", 400, "중앙 관제/정산 총괄"
+            );
+            Long dongjakId = ensureBranch(
+                    "동작점", OwnershipType.NO, "102-20-00002", "220202-2000002",
+                    "서울특별시 동작구 상도로 12길 7", "1층",
+                    "02-826-0202", "dongjak@careup.com",
+                    "카페/음료", LocalDate.now().minusYears(4),
+                    "37.5124,126.9399", 300, "대학가 상권 중심, 테이크아웃 강세"
+            );
+            Long boramaeId = ensureBranch(
+                    "보라매점", OwnershipType.YES, "103-30-00003", "330303-3000003",
+                    "서울특별시 동작구 보라매로5가길 21", "A동 102호",
+                    "02-834-0303", "boramae@careup.com",
+                    "카페/디저트", LocalDate.now().minusYears(2),
+                    "37.4924,126.9237", 250, "공원 상권, 주말 패밀리 비중 높음"
+            );
+
+            Map<String, Long> gradeIds = ensureJobGradesInTable(List.of(
+                    "바리스타", "시프트 슈퍼바이저", "부점장", "점장", "지역매니저", "본사매니저"
+            ));
+
             createEmployee(
                     "H2025001", "이승지", "hq.admin@starbucks.co.kr", "010-2331-4132", Gender.FEMALE,
                     gradeIds.get("본사매니저"),
@@ -83,7 +86,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울특별시 광진구 아차산로 200", "1203호", "05010",
                     "010-1234-1111", "차은우", Relationship.SPOUSE,
                     LocalDate.of(2003, 1, 1), LocalDate.now().minusYears(5),
-                    "https://picsum.photos/seed/hqadmin/256", "본사 총괄 관리자",
+                    DEFAULT_PROFILE_URL, "본사 총괄 관리자",
                     List.of(DispatchAssignmentDto.builder()
                             .branchId(hqId)
                             .assignedFrom(LocalDate.now().minusYears(4))
@@ -98,7 +101,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울특별시 동작구 상도로 22", "302호", "06970",
                     "010-1234-3333", "김윤아", Relationship.SIBLING,
                     LocalDate.of(1988, 11, 2), LocalDate.now().minusYears(3),
-                    "https://picsum.photos/seed/dongjakadmin/256", "동작점 직영 지점장",
+                    DEFAULT_PROFILE_URL, "동작점 직영 지점장",
                     List.of(DispatchAssignmentDto.builder()
                             .branchId(dongjakId)
                             .assignedFrom(LocalDate.now().minusYears(3))
@@ -113,7 +116,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울특별시 동작구 보라매로 30", "상가동 1층", "07060",
                     "010-7222-3333", "최민수", Relationship.PARENT,
                     LocalDate.of(1970, 5, 1), LocalDate.now().minusYears(2),
-                    "https://picsum.photos/seed/owner/256", "보라매점 가맹점주",
+                    DEFAULT_PROFILE_URL, "보라매점 가맹점주",
                     List.of(DispatchAssignmentDto.builder()
                             .branchId(boramaeId)
                             .assignedFrom(LocalDate.now().minusYears(2))
@@ -128,7 +131,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울특별시 관악구 봉천로 120", "202호", "08780",
                     "010-2222-3333", "박은주", Relationship.FRIEND,
                     LocalDate.of(1998, 1, 19), LocalDate.now().minusMonths(7),
-                    "https://picsum.photos/seed/directstaff/256", "동작점 직영 직원",
+                    DEFAULT_PROFILE_URL, "동작점 직영 직원",
                     List.of(DispatchAssignmentDto.builder()
                             .branchId(dongjakId)
                             .assignedFrom(LocalDate.now().minusMonths(6))
@@ -143,7 +146,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울특별시 영등포구 당산로 50", "1512호", "07220",
                     "010-7000-5555", "김민아", Relationship.NEIGHBOR,
                     LocalDate.of(2000, 9, 23), LocalDate.now().minusMonths(4),
-                    "https://picsum.photos/seed/frstaff/256", "보라매점 가맹 직원",
+                    DEFAULT_PROFILE_URL, "보라매점 가맹 직원",
                     List.of(DispatchAssignmentDto.builder()
                             .branchId(boramaeId)
                             .assignedFrom(LocalDate.now().minusMonths(4))
@@ -157,10 +160,15 @@ public class DataInitializer implements CommandLineRunner {
     private void runAsSystem(Runnable task) {
         Claims claims = Jwts.claims().setSubject("system@careup.com");
         claims.put("role", "HQ_ADMIN");
+        claims.put("employeeId", 0L);
+
         var auth = new UsernamePasswordAuthenticationToken(
-                "system@careup.com", null, List.of(new SimpleGrantedAuthority("ROLE_HQ_ADMIN"))
+                "system@careup.com",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_HQ_ADMIN"))
         );
         auth.setDetails(claims);
+
         var ctx = SecurityContextHolder.getContext();
         var before = ctx.getAuthentication();
         try {
@@ -190,6 +198,7 @@ public class DataInitializer implements CommandLineRunner {
                 .map(Branch::getId)
                 .findFirst();
         if (existingId.isPresent()) return existingId.get();
+
         BranchRegisterReqDto dto = BranchRegisterReqDto.builder()
                 .name(name)
                 .businessDomain(businessDomain)
@@ -248,6 +257,7 @@ public class DataInitializer implements CommandLineRunner {
                                 String remark,
                                 List<DispatchAssignmentDto> dispatches) {
         if (employeeRepository.findByEmailIgnoreCase(email).isPresent()) return;
+
         EmployeeCreateDto dto = EmployeeCreateDto.builder()
                 .employeeNumber(employeeNumber)
                 .name(name)
@@ -272,7 +282,8 @@ public class DataInitializer implements CommandLineRunner {
                 .rawPassword("care1234")
                 .dispatches(dispatches)
                 .build();
-        employeeService.create(dto);
+
+        employeeService.create(dto, null);
     }
 
     private String guessZip(String address) {

--- a/branch/src/main/java/com/careup/branch/common/service/EmailSender.java
+++ b/branch/src/main/java/com/careup/branch/common/service/EmailSender.java
@@ -1,3 +1,4 @@
+// com.careup.branch.common.service.EmailSender
 package com.careup.branch.common.service;
 
 import lombok.RequiredArgsConstructor;
@@ -6,6 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -16,6 +20,9 @@ public class EmailSender {
 
     @Value("${spring.mail.from:no-reply@careup.com}")
     private String from;
+
+    @Value("${careup.mail.reset-base-url:https://branch.careup.com/reset-password}")
+    private String resetBaseUrl;
 
     /** 공용 전송기 */
     public void send(String to, String subject, String body) {
@@ -33,19 +40,24 @@ public class EmailSender {
         }
     }
 
-    /** [Care-Up] 지점 계정 비밀번호 재설정 메일 템플릿 */
+    /** [Care-Up] 지점 계정 비밀번호 재설정 메일 (링크 포함) */
     public void sendPasswordReset(String toEmail, String token) {
-        String subject = "[Care-Up] 지점 계정 비밀번호 재설정 안내";
+        String encEmail = URLEncoder.encode(toEmail, StandardCharsets.UTF_8);
+        String encToken = URLEncoder.encode(token, StandardCharsets.UTF_8);
+        String link = resetBaseUrl + "?email=" + encEmail + "&token=" + encToken;
+
+        String subject = "[Care-Up] 지점 계정 비밀번호 재설정 안내 (15분 내 유효)";
         String body = """
                 안녕하세요.
 
-                아래 토큰으로 15분 내 비밀번호를 재설정하세요.
+                비밀번호 재설정을 요청하셨습니다.
+                아래 링크로 접속하여 새 비밀번호를 설정해 주세요. (유효시간: 15분)
 
-                이메일: %s
-                토큰: %s
+                재설정 링크: %s
 
-                이 메일을 요청하지 않으셨다면 무시하셔도 됩니다.
-                """.formatted(toEmail, token);
+                만약 본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.
+                """.formatted(link);
+
         send(toEmail, subject, body);
     }
 }

--- a/branch/src/main/java/com/careup/branch/common/service/EmailSender.java
+++ b/branch/src/main/java/com/careup/branch/common/service/EmailSender.java
@@ -1,0 +1,51 @@
+package com.careup.branch.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.from:no-reply@careup.com}")
+    private String from;
+
+    /** 공용 전송기 */
+    public void send(String to, String subject, String body) {
+        SimpleMailMessage m = new SimpleMailMessage();
+        m.setFrom(from);
+        m.setTo(to);
+        m.setSubject(subject);
+        m.setText(body);
+        try {
+            mailSender.send(m);
+            log.info("[MAIL] sent to={}", to);
+        } catch (Exception e) {
+            log.error("[MAIL] send failed to={} : {}", to, e.getMessage(), e);
+            throw new RuntimeException("이메일 전송에 실패했습니다.");
+        }
+    }
+
+    /** [Care-Up] 지점 계정 비밀번호 재설정 메일 템플릿 */
+    public void sendPasswordReset(String toEmail, String token) {
+        String subject = "[Care-Up] 지점 계정 비밀번호 재설정 안내";
+        String body = """
+                안녕하세요.
+
+                아래 토큰으로 15분 내 비밀번호를 재설정하세요.
+
+                이메일: %s
+                토큰: %s
+
+                이 메일을 요청하지 않으셨다면 무시하셔도 됩니다.
+                """.formatted(toEmail, token);
+        send(toEmail, subject, body);
+    }
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/controller/AuthController.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/controller/AuthController.java
@@ -2,11 +2,16 @@ package com.careup.branch.domain.auth.controller;
 
 import com.careup.branch.common.dto.CommonSuccessDto;
 import com.careup.branch.domain.auth.dto.request.AuthLoginRequest;
+import com.careup.branch.domain.auth.dto.request.RefreshRequest;
+import com.careup.branch.domain.auth.dto.request.LogoutRequest;
 import com.careup.branch.domain.auth.dto.response.AuthLoginResponse;
+import com.careup.branch.domain.auth.dto.response.AuthRefreshResponse;
+import com.careup.branch.domain.auth.dto.response.AuthLogoutResponse;
 import com.careup.branch.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -24,6 +29,46 @@ public class AuthController {
                         .result(result)
                         .status_code(HttpStatus.OK.value())
                         .status_message("로그인 성공")
+                        .build()
+        );
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<CommonSuccessDto> refresh(@RequestBody RefreshRequest req) {
+        if (!StringUtils.hasText(req.getRefreshToken())) {
+            return ResponseEntity.badRequest().body(
+                    CommonSuccessDto.builder()
+                            .status_code(HttpStatus.BAD_REQUEST.value())
+                            .status_message("refreshToken은 필수입니다.")
+                            .build()
+            );
+        }
+        AuthRefreshResponse result = authService.refresh(req.getRefreshToken());
+        return ResponseEntity.ok(
+                CommonSuccessDto.builder()
+                        .result(result)
+                        .status_code(HttpStatus.OK.value())
+                        .status_message("액세스 토큰이 재발급되었습니다.")
+                        .build()
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<CommonSuccessDto> logout(@RequestBody LogoutRequest req) {
+        if (!StringUtils.hasText(req.getRefreshToken())) {
+            return ResponseEntity.badRequest().body(
+                    CommonSuccessDto.builder()
+                            .status_code(HttpStatus.BAD_REQUEST.value())
+                            .status_message("refreshToken은 필수입니다.")
+                            .build()
+            );
+        }
+        AuthLogoutResponse result = authService.logout(req.getRefreshToken());
+        return ResponseEntity.ok(
+                CommonSuccessDto.builder()
+                        .result(result)
+                        .status_code(HttpStatus.OK.value())
+                        .status_message("로그아웃 되었습니다.")
                         .build()
         );
     }

--- a/branch/src/main/java/com/careup/branch/domain/auth/controller/AuthController.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/controller/AuthController.java
@@ -1,9 +1,8 @@
+// com.careup.branch.domain.auth.controller.AuthController
 package com.careup.branch.domain.auth.controller;
 
 import com.careup.branch.common.dto.CommonSuccessDto;
-import com.careup.branch.domain.auth.dto.request.AuthLoginRequest;
-import com.careup.branch.domain.auth.dto.request.RefreshRequest;
-import com.careup.branch.domain.auth.dto.request.LogoutRequest;
+import com.careup.branch.domain.auth.dto.request.*;
 import com.careup.branch.domain.auth.dto.response.AuthLoginResponse;
 import com.careup.branch.domain.auth.dto.response.AuthRefreshResponse;
 import com.careup.branch.domain.auth.dto.response.AuthLogoutResponse;
@@ -13,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/auth")
@@ -48,7 +49,7 @@ public class AuthController {
                 CommonSuccessDto.builder()
                         .result(result)
                         .status_code(HttpStatus.OK.value())
-                        .status_message("액세스 토큰이 재발급되었습니다.")
+                        .status_message("액세스 토큰 재발급 완료")
                         .build()
         );
     }
@@ -68,7 +69,38 @@ public class AuthController {
                 CommonSuccessDto.builder()
                         .result(result)
                         .status_code(HttpStatus.OK.value())
-                        .status_message("로그아웃 되었습니다.")
+                        .status_message("로그아웃 완료")
+                        .build()
+        );
+    }
+
+    /** (NEW) 비밀번호 재설정 메일 요청: 이메일+휴대폰 모두 필요 */
+    @PostMapping("/password/forgot")
+    public ResponseEntity<CommonSuccessDto> forgot(@RequestBody @Valid ForgotPasswordRequest req) {
+        authService.issueResetTokenByIdentity(req.getEmail().trim(), req.getMobile().trim());
+        return ResponseEntity.ok(
+                CommonSuccessDto.builder()
+                        .result("ok")
+                        .status_code(200)
+                        .status_message("비밀번호 재설정 메일 전송 완료 (15분 내 유효)")
+                        .build()
+        );
+    }
+
+    /** (NEW) 비밀번호 재설정 완료 */
+    @PostMapping("/password/reset")
+    public ResponseEntity<CommonSuccessDto> reset(@RequestBody @Valid ResetPasswordRequest req) {
+        authService.resetPassword(
+                req.getEmail().trim(),
+                req.getToken().trim(),
+                req.getNewPassword().trim(),
+                req.getConfirmPassword().trim()
+        );
+        return ResponseEntity.ok(
+                CommonSuccessDto.builder()
+                        .result("ok")
+                        .status_code(200)
+                        .status_message("비밀번호 재설정 완료")
                         .build()
         );
     }

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/AuthLoginRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/AuthLoginRequest.java
@@ -1,10 +1,12 @@
 package com.careup.branch.domain.auth.dto.request;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class AuthLoginRequest {
     private String id;           /// 이메일 또는 휴대폰 번호
     private String password;     /// 평문 비밀번호

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ForgotPasswordRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ForgotPasswordRequest.java
@@ -1,5 +1,6 @@
 package com.careup.branch.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -9,6 +10,10 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class ForgotPasswordRequest {
+    @Email
     @NotBlank
-    private String id;  // 이메일 또는 휴대폰(메일 발송은 이메일 기준)
+    private String email;   // DB의 이메일과 일치해야 함
+
+    @NotBlank
+    private String mobile;  // DB의 휴대폰 번호와 일치해야 함(하이픈 유무 무관)
 }

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ForgotPasswordRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ForgotPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.careup.branch.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ForgotPasswordRequest {
+    @NotBlank
+    private String id;  // 이메일 또는 휴대폰(메일 발송은 이메일 기준)
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/LogoutRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,14 @@
+package com.careup.branch.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LogoutRequest {
+    @NotBlank
+    private String refreshToken;
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/RefreshRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,14 @@
+package com.careup.branch.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshRequest {
+    @NotBlank
+    private String refreshToken;
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ResetPasswordRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ResetPasswordRequest.java
@@ -1,5 +1,6 @@
 package com.careup.branch.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -9,10 +10,16 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class ResetPasswordRequest {
+    @Email
     @NotBlank
-    private String id;       // 이메일
+    private String email;            // 토큰과 매칭할 이메일
+
     @NotBlank
-    private String token;
+    private String token;            // 메일에 첨부된 토큰
+
     @NotBlank
-    private String newPassword;
+    private String newPassword;      // 새 비밀번호
+
+    @NotBlank
+    private String confirmPassword;  // 새 비밀번호 확인
 }

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ResetPasswordRequest.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,18 @@
+package com.careup.branch.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResetPasswordRequest {
+    @NotBlank
+    private String id;       // 이메일
+    @NotBlank
+    private String token;
+    @NotBlank
+    private String newPassword;
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/response/AuthLogoutResponse.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/response/AuthLogoutResponse.java
@@ -1,24 +1,20 @@
 package com.careup.branch.domain.auth.dto.response;
 
 import lombok.*;
+import java.time.Instant;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AuthLoginResponse {
-    private String tokenType;
-    private String accessToken;
-    private String refreshToken; // rememberMe=false면 null
-    private int expiresInMinutes;
-    private String role;
+public class AuthLogoutResponse {
+    private boolean tokenRevoked;     // 항상 true
     private Long employeeId;
-
     private String name;
-    private String title;
     private String email;
     private String mobile;
-
+    private String role;
     private Long branchId;
     private String branchName;
+    private Instant revokedAt;        // 로그아웃 시각
 }

--- a/branch/src/main/java/com/careup/branch/domain/auth/dto/response/AuthRefreshResponse.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/dto/response/AuthRefreshResponse.java
@@ -1,0 +1,24 @@
+package com.careup.branch.domain.auth.dto.response;
+
+import lombok.*;
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthRefreshResponse {
+    private String tokenType;         // "Bearer"
+    private String accessToken;       // 새 AT
+    private int expiresInMinutes;     // AT 만료(분)
+
+    private Long employeeId;
+    private String name;
+    private String email;
+    private String mobile;
+    private String role;
+    private Long branchId;
+    private String branchName;
+
+    private Instant issuedAt;         // 재발급 시각
+}

--- a/branch/src/main/java/com/careup/branch/domain/auth/service/AuthService.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/service/AuthService.java
@@ -2,19 +2,26 @@ package com.careup.branch.domain.auth.service;
 
 import com.careup.branch.common.auth.JwtProperties;
 import com.careup.branch.common.auth.JwtTokenProvider;
+import com.careup.branch.common.auth.PasswordResetTokenStore;
+import com.careup.branch.common.service.EmailSender;
 import com.careup.branch.common.util.PhoneUtils;
 import com.careup.branch.domain.auth.dto.request.AuthLoginRequest;
 import com.careup.branch.domain.auth.dto.response.AuthLoginResponse;
+import com.careup.branch.domain.auth.dto.response.AuthLogoutResponse;
+import com.careup.branch.domain.auth.dto.response.AuthRefreshResponse;
 import com.careup.branch.domain.employee.entity.DispatchStatus;
 import com.careup.branch.domain.employee.entity.Employee;
 import com.careup.branch.domain.employee.repository.DispatchStatusRepository;
 import com.careup.branch.domain.employee.repository.EmployeeRepository;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,47 +34,47 @@ public class AuthService {
     private final JwtTokenProvider jwt;
     private final JwtProperties jwtProps;
 
+    private final PasswordResetTokenStore passwordResetTokenStore;
+    private final EmailSender emailSender;
+
+    /** 이메일 또는 휴대폰 로그인 → employeeId 기준 AT/RT(옵션) 발급 */
     public AuthLoginResponse login(AuthLoginRequest req) {
-        if (req.getId() == null || req.getId().isBlank()) {
+        if (req.getId() == null || req.getId().isBlank())
             throw new IllegalArgumentException("아이디(이메일 또는 휴대폰 번호)는 필수입니다.");
-        }
-        if (req.getPassword() == null || req.getPassword().isBlank()) {
+        if (req.getPassword() == null || req.getPassword().isBlank())
             throw new IllegalArgumentException("비밀번호는 필수입니다.");
-        }
 
         final String rawId = req.getId().trim();
+        final boolean emailLogin = rawId.contains("@");
+        final String loginId = emailLogin ? rawId : PhoneUtils.normalize(rawId);
 
-        Employee emp = rawId.contains("@")
-                ? employeeRepository.findByEmailIgnoreCase(rawId)
+        Employee emp = emailLogin
+                ? employeeRepository.findByEmailIgnoreCase(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."))
-                : employeeRepository.findByMobile(PhoneUtils.normalize(rawId))
+                : employeeRepository.findByMobile(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 휴대폰 번호입니다."));
 
-        if (!Boolean.TRUE.equals(emp.getEnabled())) {
+        if (!Boolean.TRUE.equals(emp.getEnabled()))
             throw new IllegalArgumentException("비활성화된 계정입니다.");
-        }
-        if (!passwordEncoder.matches(req.getPassword(), emp.getPasswordHash())) {
+        if (!passwordEncoder.matches(req.getPassword(), emp.getPasswordHash()))
             throw new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다.");
-        }
 
         String role = emp.getAuthorityType().name();
-        String at = jwt.createAccessToken(emp.getEmail(), role, emp.getId());
-        String rt = jwt.createRefreshToken(emp.getEmail(), req.isRememberMe());
+        Long employeeId = emp.getId();
 
+        String at = jwt.createAccessToken(employeeId, role);
+        String rt = jwt.createRefreshToken(employeeId, req.isRememberMe()); // rememberMe=false면 null
+
+        // 배치 지점
         LocalDate today = LocalDate.now();
-        var activeDispatchOpt = dispatchStatusRepository
+        Optional<DispatchStatus> active = dispatchStatusRepository
                 .findFirstByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqualOrderByAssignedFromDesc(
-                        emp, "N", today, today
-                );
+                        emp, "N", today, today);
 
-        Long branchId = null;
-        String branchName = null;
-        if (activeDispatchOpt.isPresent()) {
-            DispatchStatus d = activeDispatchOpt.get();
-            if (d.getBranch() != null) {
-                branchId = d.getBranch().getId();
-                branchName = d.getBranch().getName();
-            }
+        Long branchId = null; String branchName = null;
+        if (active.isPresent() && active.get().getBranch() != null) {
+            branchId = active.get().getBranch().getId();
+            branchName = active.get().getBranch().getName();
         }
 
         String title = (emp.getJobGrade() != null) ? emp.getJobGrade().getName() : null;
@@ -75,10 +82,10 @@ public class AuthService {
         return AuthLoginResponse.builder()
                 .tokenType("Bearer")
                 .accessToken(at)
-                .refreshToken(rt)
+                .refreshToken(rt) // null 가능
                 .expiresInMinutes(jwtProps.getAccessTokenExpiryMinutes())
                 .role(role)
-                .employeeId(emp.getId())
+                .employeeId(employeeId)
                 .name(emp.getName())
                 .title(title)
                 .email(emp.getEmail())
@@ -86,6 +93,103 @@ public class AuthService {
                 .branchId(branchId)
                 .branchName(branchName)
                 .build();
+    }
+
+    /** 자동로그인: RT로 AT 재발급 (메시지 없음 DTO) */
+    public AuthRefreshResponse refresh(String refreshToken) {
+        Claims claims = jwt.validateRefreshToken(refreshToken);
+        Long employeeId = Long.valueOf(claims.getSubject());
+
+        Employee emp = employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+        String role = emp.getAuthorityType().name();
+
+        String at = jwt.createAccessToken(employeeId, role);
+
+        LocalDate today = LocalDate.now();
+        Optional<DispatchStatus> active = dispatchStatusRepository
+                .findFirstByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqualOrderByAssignedFromDesc(
+                        emp, "N", today, today);
+
+        Long branchId = null; String branchName = null;
+        if (active.isPresent() && active.get().getBranch() != null) {
+            branchId = active.get().getBranch().getId();
+            branchName = active.get().getBranch().getName();
+        }
+
+        return AuthRefreshResponse.builder()
+                .tokenType("Bearer")
+                .accessToken(at)
+                .expiresInMinutes(jwtProps.getAccessTokenExpiryMinutes())
+                .employeeId(employeeId)
+                .name(emp.getName())
+                .email(emp.getEmail())
+                .mobile(emp.getMobile())
+                .role(role)
+                .branchId(branchId)
+                .branchName(branchName)
+                .issuedAt(Instant.now())
+                .build();
+    }
+
+    /** 로그아웃: RT 폐기 (메시지 없음 DTO) */
+    @Transactional
+    public AuthLogoutResponse logout(String refreshToken) {
+        Claims claims = jwt.validateRefreshToken(refreshToken);
+        Long employeeId = Long.valueOf(claims.getSubject());
+
+        Employee emp = employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+
+        LocalDate today = LocalDate.now();
+        Optional<DispatchStatus> active = dispatchStatusRepository
+                .findFirstByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqualOrderByAssignedFromDesc(
+                        emp, "N", today, today);
+
+        Long branchId = null; String branchName = null;
+        if (active.isPresent() && active.get().getBranch() != null) {
+            branchId = active.get().getBranch().getId();
+            branchName = active.get().getBranch().getName();
+        }
+
+        jwt.revokeRefreshToken(employeeId);
+
+        return AuthLogoutResponse.builder()
+                .tokenRevoked(true)
+                .employeeId(employeeId)
+                .name(emp.getName())
+                .email(emp.getEmail())
+                .mobile(emp.getMobile())
+                .role(emp.getAuthorityType().name())
+                .branchId(branchId)
+                .branchName(branchName)
+                .revokedAt(Instant.now())
+                .build();
+    }
+
+    /** 이메일로 비밀번호 재설정 토큰 발급 */
+    @Transactional
+    public void issueResetToken(String email) {
+        employeeRepository.findByEmailIgnoreCase(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 계정을 찾을 수 없습니다."));
+        String token = passwordResetTokenStore.issue(email);
+        emailSender.sendPasswordReset(email, token);
+    }
+
+    /** 이메일 토큰으로 비밀번호 재설정 */
+    @Transactional
+    public void resetPassword(String email, String token, String newPassword) {
+        String saved = passwordResetTokenStore.get(email)
+                .orElseThrow(() -> new IllegalArgumentException("재설정 토큰이 만료되었거나 존재하지 않습니다."));
+        if (!saved.equals(token))
+            throw new IllegalArgumentException("재설정 토큰이 올바르지 않습니다.");
+        if (!isStrongPassword(newPassword))
+            throw new IllegalArgumentException("비밀번호는 8자 이상이며 영문/숫자를 포함해야 합니다.");
+
+        Employee emp = employeeRepository.findByEmailIgnoreCase(email)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+        emp.changePasswordHash(passwordEncoder.encode(newPassword));
+        passwordResetTokenStore.delete(email);
     }
 
     public static boolean isStrongPassword(String raw) {

--- a/branch/src/main/java/com/careup/branch/domain/auth/service/AuthService.java
+++ b/branch/src/main/java/com/careup/branch/domain/auth/service/AuthService.java
@@ -1,3 +1,4 @@
+// com.careup.branch.domain.auth.service.AuthService
 package com.careup.branch.domain.auth.service;
 
 import com.careup.branch.common.auth.JwtProperties;
@@ -37,7 +38,7 @@ public class AuthService {
     private final PasswordResetTokenStore passwordResetTokenStore;
     private final EmailSender emailSender;
 
-    /** 이메일 또는 휴대폰 로그인 → employeeId 기준 AT/RT(옵션) 발급 */
+    /** 이메일 또는 휴대폰 로그인 → employeeId 기준 AT/RT 발급 */
     public AuthLoginResponse login(AuthLoginRequest req) {
         if (req.getId() == null || req.getId().isBlank())
             throw new IllegalArgumentException("아이디(이메일 또는 휴대폰 번호)는 필수입니다.");
@@ -63,7 +64,9 @@ public class AuthService {
         Long employeeId = emp.getId();
 
         String at = jwt.createAccessToken(employeeId, role);
-        String rt = jwt.createRefreshToken(employeeId, req.isRememberMe()); // rememberMe=false면 null
+
+        // rememberMe=false면 RT 미발급을 원하면 아래를 null 처리하세요.
+        String rt = jwt.createRefreshToken(employeeId, req.isRememberMe());
 
         // 배치 지점
         LocalDate today = LocalDate.now();
@@ -82,7 +85,7 @@ public class AuthService {
         return AuthLoginResponse.builder()
                 .tokenType("Bearer")
                 .accessToken(at)
-                .refreshToken(rt) // null 가능
+                .refreshToken(rt) // rememberMe=false 시 null로 바꾸려면 여기 조정
                 .expiresInMinutes(jwtProps.getAccessTokenExpiryMinutes())
                 .role(role)
                 .employeeId(employeeId)
@@ -95,7 +98,7 @@ public class AuthService {
                 .build();
     }
 
-    /** 자동로그인: RT로 AT 재발급 (메시지 없음 DTO) */
+    /** 자동로그인: RT로 AT 재발급 */
     public AuthRefreshResponse refresh(String refreshToken) {
         Claims claims = jwt.validateRefreshToken(refreshToken);
         Long employeeId = Long.valueOf(claims.getSubject());
@@ -132,7 +135,7 @@ public class AuthService {
                 .build();
     }
 
-    /** 로그아웃: RT 폐기 (메시지 없음 DTO) */
+    /** 로그아웃: RT 폐기 */
     @Transactional
     public AuthLogoutResponse logout(String refreshToken) {
         Claims claims = jwt.validateRefreshToken(refreshToken);
@@ -167,18 +170,33 @@ public class AuthService {
                 .build();
     }
 
-    /** 이메일로 비밀번호 재설정 토큰 발급 */
+    /** (NEW) 비밀번호 재설정 메일 발송: 이메일+휴대폰 모두 DB와 일치해야 함 */
     @Transactional
-    public void issueResetToken(String email) {
-        employeeRepository.findByEmailIgnoreCase(email)
+    public void issueResetTokenByIdentity(String email, String mobile) {
+        String normalizedMobile = PhoneUtils.normalize(mobile);
+
+        Employee emp = employeeRepository.findByEmailIgnoreCase(email)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 계정을 찾을 수 없습니다."));
+
+        // 이메일은 위에서 일치, 휴대폰 일치 추가 확인
+        if (!normalizedMobile.equals(PhoneUtils.normalize(emp.getMobile()))) {
+            throw new IllegalArgumentException("이메일과 휴대폰 정보가 일치하지 않습니다.");
+        }
+
+        // 토큰 발급(키는 email 기준)
         String token = passwordResetTokenStore.issue(email);
+
+        // 메일 발송(링크 포함)
         emailSender.sendPasswordReset(email, token);
     }
 
-    /** 이메일 토큰으로 비밀번호 재설정 */
+    /** (NEW) 토큰으로 비밀번호 재설정: 확인값까지 검증 */
     @Transactional
-    public void resetPassword(String email, String token, String newPassword) {
+    public void resetPassword(String email, String token, String newPassword, String confirmPassword) {
+        if (!newPassword.equals(confirmPassword)) {
+            throw new IllegalArgumentException("새 비밀번호와 확인 값이 일치하지 않습니다.");
+        }
+
         String saved = passwordResetTokenStore.get(email)
                 .orElseThrow(() -> new IllegalArgumentException("재설정 토큰이 만료되었거나 존재하지 않습니다."));
         if (!saved.equals(token))
@@ -189,6 +207,8 @@ public class AuthService {
         Employee emp = employeeRepository.findByEmailIgnoreCase(email)
                 .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
         emp.changePasswordHash(passwordEncoder.encode(newPassword));
+
+        // 토큰 1회성 소진
         passwordResetTokenStore.delete(email);
     }
 

--- a/branch/src/main/java/com/careup/branch/domain/employee/controller/EmployeeController.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/controller/EmployeeController.java
@@ -8,9 +8,11 @@ import com.careup.branch.domain.employee.service.EmployeeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/employee")
@@ -19,11 +21,13 @@ public class EmployeeController {
 
     private final EmployeeService employeeService;
 
-    /// 직원 생성 (HQ_ADMIN, BRANCH_ADMIN, FRANCHISE_OWNER) + 최초 배치
-    @PostMapping("/create")
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAnyRole('HQ_ADMIN','BRANCH_ADMIN','FRANCHISE_OWNER')")
-    public ResponseEntity<CommonSuccessDto> create(@Valid @RequestBody EmployeeCreateDto req) {
-        EmployeeDetailDto result = employeeService.create(req);
+    public ResponseEntity<CommonSuccessDto> create(
+            @Valid @RequestPart("meta") EmployeeCreateDto meta,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        EmployeeDetailDto result = employeeService.create(meta, image);
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 CommonSuccessDto.builder()
                         .result(result)
@@ -33,12 +37,14 @@ public class EmployeeController {
         );
     }
 
-    /// 직원 수정 (HQ_ADMIN, BRANCH_ADMIN, FRANCHISE_OWNER)
-    @PatchMapping("/update/{id}")
+    @PatchMapping(value = "/update/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAnyRole('HQ_ADMIN','BRANCH_ADMIN','FRANCHISE_OWNER')")
-    public ResponseEntity<CommonSuccessDto> update(@PathVariable Long id,
-                                                   @Valid @RequestBody EmployeeUpdateDto req) {
-        EmployeeDetailDto result = employeeService.update(id, req);
+    public ResponseEntity<CommonSuccessDto> update(
+            @PathVariable Long id,
+            @Valid @RequestPart("meta") EmployeeUpdateDto meta,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        EmployeeDetailDto result = employeeService.update(id, meta, image);
         return ResponseEntity.status(HttpStatus.OK).body(
                 CommonSuccessDto.builder()
                         .result(result)
@@ -48,16 +54,28 @@ public class EmployeeController {
         );
     }
 
-    /// 직원 삭제 (HQ_ADMIN, BRANCH_ADMIN, FRANCHISE_OWNER)
     @DeleteMapping("/delete/{id}")
     @PreAuthorize("hasAnyRole('HQ_ADMIN','BRANCH_ADMIN','FRANCHISE_OWNER')")
     public ResponseEntity<CommonSuccessDto> delete(@PathVariable Long id) {
-        employeeService.delete(id);
+        employeeService.deactivate(id);
         return ResponseEntity.status(HttpStatus.OK).body(
                 CommonSuccessDto.builder()
                         .result("ok")
                         .status_code(HttpStatus.OK.value())
-                        .status_message("직원 삭제 완료")
+                        .status_message("직원 비활성화(퇴사) 처리 완료")
+                        .build()
+        );
+    }
+
+    @PatchMapping("/rehire/{id}")
+    @PreAuthorize("hasAnyRole('HQ_ADMIN','BRANCH_ADMIN','FRANCHISE_OWNER')")
+    public ResponseEntity<CommonSuccessDto> rehire(@PathVariable Long id) {
+        EmployeeDetailDto result = employeeService.rehire(id);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                CommonSuccessDto.builder()
+                        .result(result)
+                        .status_code(HttpStatus.OK.value())
+                        .status_message("재입사 처리 완료")
                         .build()
         );
     }

--- a/branch/src/main/java/com/careup/branch/domain/employee/dto/request/DocumentCreateDto.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/dto/request/DocumentCreateDto.java
@@ -1,0 +1,13 @@
+package com.careup.branch.domain.employee.dto.request;
+
+import com.careup.branch.domain.employee.entity.DocumentType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DocumentCreateDto {
+    @NotNull
+    private DocumentType documentType;
+}

--- a/branch/src/main/java/com/careup/branch/domain/employee/dto/request/EmployeeCreateDto.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/dto/request/EmployeeCreateDto.java
@@ -23,10 +23,11 @@ public class EmployeeCreateDto {
     @Size(max = 100)
     private String name;
 
-    private Long jobGradeId; // nullable
+    private Long jobGradeId;
 
     @NotNull
     private LocalDate dateOfBirth;
+
     @NotNull
     private Gender gender;
 
@@ -40,6 +41,7 @@ public class EmployeeCreateDto {
 
     @NotBlank
     private String address;
+
     @NotBlank
     private String addressDetail;
 
@@ -57,18 +59,21 @@ public class EmployeeCreateDto {
 
     @NotNull
     private Relationship relationship;
+
     @NotNull
     private LocalDate hireDate;
+
     private LocalDate terminateDate;
 
     @NotNull
     private AuthorityType authorityType;
+
     @NotNull
     private EmploymentStatus employmentStatus;
+
     @NotNull
     private EmploymentType employmentType;
 
-    @NotBlank
     private String profileImageUrl;
 
     @Size(max = 200)
@@ -78,7 +83,6 @@ public class EmployeeCreateDto {
     @Size(min = 8, max = 100)
     private String rawPassword;
 
-    /// 최초 배치(여러 개 가능)
     @Valid
     @Size(min = 1, message = "최소 1개 지점 배치가 필요합니다.")
     private List<DispatchAssignmentDto> dispatches;

--- a/branch/src/main/java/com/careup/branch/domain/employee/dto/request/EmployeeUpdateDto.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/dto/request/EmployeeUpdateDto.java
@@ -23,10 +23,11 @@ public class EmployeeUpdateDto {
     @Size(max = 100)
     private String name;
 
-    private Long jobGradeId; // nullable
+    private Long jobGradeId;
 
     @NotNull
     private LocalDate dateOfBirth;
+
     @NotNull
     private Gender gender;
 
@@ -40,6 +41,7 @@ public class EmployeeUpdateDto {
 
     @NotBlank
     private String address;
+
     @NotBlank
     private String addressDetail;
 
@@ -60,16 +62,18 @@ public class EmployeeUpdateDto {
 
     @NotNull
     private LocalDate hireDate;
+
     private LocalDate terminateDate;
 
     @NotNull
     private AuthorityType authorityType;
+
     @NotNull
     private EmploymentStatus employmentStatus;
+
     @NotNull
     private EmploymentType employmentType;
 
-    @NotBlank
     private String profileImageUrl;
 
     @Size(max = 200)

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/DispatchStatus.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/DispatchStatus.java
@@ -3,12 +3,7 @@ package com.careup.branch.domain.employee.entity;
 import com.careup.branch.common.domain.BaseTimeEntity;
 import com.careup.branch.domain.branch.entity.Branch;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -22,31 +17,30 @@ public class DispatchStatus extends BaseTimeEntity {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
 
-    //배치 현황 N:1 직원
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="employee_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Employee employee;
 
-    //배치 현황 N:1 지점
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="branch_id")
     private Branch branch;
 
-    //배치 시작일
     @Column(name = "assigned_from", nullable = false)
     private LocalDate assignedFrom;
 
-    //배치 종료일
     @Column(name = "assigned_to", nullable = false)
     private LocalDate assignedTo;
 
-    //배치 취소 일자
     @Column(name = "displacement_date")
     private LocalDate displacementDate;
 
-    // 배치 취소 여부(Y/N) – 기본 N
     @Column(name = "placement_yn", nullable = false, length = 1)
     @Builder.Default
     private String placementYn = "N";
+
+    public void endAssignment(LocalDate endDate) {
+        this.assignedTo = endDate;
+        this.placementYn = "Y";
+        this.displacementDate = endDate;
+    }
 }

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/DocumentType.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/DocumentType.java
@@ -1,6 +1,15 @@
 package com.careup.branch.domain.employee.entity;
 
 public enum DocumentType {
-    EMPLOYMENT_CONTRACT, // 고용계약서
-    FRANCHISE_CONTRACT   // 가맹계약서
+    EMPLOYMENT_CONTRACT,                    // 고용계약서
+    FRANCHISE_CONTRACT,                     // 가맹계약서
+    BUSINESS_REGISTRATION_CERTIFICATE,      // 사업자등록증
+    CORPORATE_REGISTRATION_CERTIFICATE,     // 법인등기부등본
+    SHAREHOLDER_REGISTER,                   // 주주명부
+    CORPORATE_SEAL_CERTIFICATE,             // 법인인감증명서
+    PERSONAL_SEAL_CERTIFICATE,              // 개인인감증명서
+    IDENTIFICATION_CARD,                    // 신분증
+    BANK_ACCOUNT_PROOF,                     // 통장사본
+    CREDIT_REPORT,                          // 신용조회서
+    ETC                                     // 기타
 }

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/Documents.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/Documents.java
@@ -2,10 +2,7 @@ package com.careup.branch.domain.employee.entity;
 
 import com.careup.branch.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -24,6 +21,10 @@ public class Documents extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 40)
     private DocumentType documentType;
+
+    /// 관리자 입력 문서명 (ex: 임성후 근로계약서, 이승지 인감증명서, 최재혁 가맹계약서)
+    @Column(name = "title", length = 200, nullable = false)
+    private String title;
 
     @Column(name = "document_url", columnDefinition = "TEXT", nullable = false)
     private String documentUrl;

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/Employee.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/Employee.java
@@ -28,11 +28,7 @@ public class Employee extends BaseTimeEntity {
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(
-            name = "job_grade_id",
-            nullable = true,
-            foreignKey = @ForeignKey(name = "fk_employee_job_grade")
-    )
+    @JoinColumn(name = "job_grade_id", nullable = true, foreignKey = @ForeignKey(name = "fk_employee_job_grade"))
     private JobGrade jobGrade;
 
     @Column(nullable = false)
@@ -127,5 +123,22 @@ public class Employee extends BaseTimeEntity {
 
     public void changePasswordHash(String encoded) {
         this.passwordHash = encoded;
+    }
+
+    public void changeProfileImageUrl(String url) {
+        this.profileImageUrl = url;
+    }
+
+    public void deactivate(LocalDate terminatedAt) {
+        this.employmentStatus = EmploymentStatus.TERMINATED;
+        this.terminateDate = terminatedAt;
+        this.enabled = false;
+    }
+
+    public void rehire(LocalDate newHireDate) {
+        this.employmentStatus = EmploymentStatus.ACTIVE;
+        this.terminateDate = null;
+        this.hireDate = newHireDate;
+        this.enabled = true;
     }
 }

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/ScheduleEvent.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/ScheduleEvent.java
@@ -46,12 +46,17 @@ public class ScheduleEvent extends BaseTimeEntity {
     @Column(name = "clock_out_at", nullable = true)
     private LocalDateTime clockOutAt;
 
-    //출근 위치
-    @Column(name = "clock_in_location", nullable = true, columnDefinition = "POINT")
-    private Point clockInLocation;
+    //출근 위치 (위도, 경도)
+    @Column(name = "clock_in_lat", precision = 9, scale = 6)
+    private Double clockInLat;
 
-    //퇴근 위치
-    @Column(name = "clock_out_location", nullable = true)
-    private Point clockOutLocation;
+    @Column(name = "clock_in_lon", precision = 9, scale = 6)
+    private Double clockInLon;
 
+    //퇴근 위치 (위도, 경도)
+    @Column(name = "clock_out_lat", precision = 9, scale = 6)
+    private Double clockOutLat;
+
+    @Column(name = "clock_out_lon", precision = 9, scale = 6)
+    private Double clockOutLon;
 }

--- a/branch/src/main/java/com/careup/branch/domain/employee/entity/ScheduleEvent.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/entity/ScheduleEvent.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -18,45 +18,45 @@ import java.time.LocalDateTime;
 @Builder
 public class ScheduleEvent extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // 근태 기록 1:1 근태
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="schedule_id")
+    @JoinColumn(name = "schedule_id")
     private Schedule schedule;
 
     // 실제 날짜
-    @Column(name = "event_date", nullable = true)
+    @Column(name = "event_date")
     private LocalDate eventDate;
 
-    //실제 출근 시간
-    @Column(name = "clock_in_at", nullable = true)
+    // 실제 출근 시간
+    @Column(name = "clock_in_at")
     private LocalDateTime clockInAt;
 
-    //실제 휴게 시작
-    @Column(name = "break_start_at", nullable = true)
+    // 실제 휴게 시작
+    @Column(name = "break_start_at")
     private LocalDateTime breakStartAt;
 
-    //실제 휴게 종료
-    @Column(name = "break_end_at", nullable = true)
+    // 실제 휴게 종료
+    @Column(name = "break_end_at")
     private LocalDateTime breakEndAt;
 
-    //실제 퇴근 시간
-    @Column(name = "clock_out_at", nullable = true)
+    // 실제 퇴근 시간
+    @Column(name = "clock_out_at")
     private LocalDateTime clockOutAt;
 
-    //출근 위치 (위도, 경도)
+    // 출근 위치 (위도, 경도) - BigDecimal로 정밀도 지정
     @Column(name = "clock_in_lat", precision = 9, scale = 6)
-    private Double clockInLat;
+    private BigDecimal clockInLat;
 
     @Column(name = "clock_in_lon", precision = 9, scale = 6)
-    private Double clockInLon;
+    private BigDecimal clockInLon;
 
-    //퇴근 위치 (위도, 경도)
+    // 퇴근 위치 (위도, 경도) - BigDecimal로 정밀도 지정
     @Column(name = "clock_out_lat", precision = 9, scale = 6)
-    private Double clockOutLat;
+    private BigDecimal clockOutLat;
 
     @Column(name = "clock_out_lon", precision = 9, scale = 6)
-    private Double clockOutLon;
+    private BigDecimal clockOutLon;
 }

--- a/branch/src/main/java/com/careup/branch/domain/employee/service/EmployeeService.java
+++ b/branch/src/main/java/com/careup/branch/domain/employee/service/EmployeeService.java
@@ -1,5 +1,6 @@
 package com.careup.branch.domain.employee.service;
 
+import com.careup.branch.common.file.AwsS3Uploader;
 import com.careup.branch.common.util.PhoneUtils;
 import com.careup.branch.domain.branch.entity.Branch;
 import com.careup.branch.domain.branch.repository.BranchRepository;
@@ -24,6 +25,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -39,9 +41,13 @@ public class EmployeeService {
     private final BranchRepository branchRepository;
     private final DispatchStatusRepository dispatchStatusRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AwsS3Uploader awsS3Uploader;
+
+    private static final String DEFAULT_PROFILE_URL =
+            "https://beyond-16-care-up.s3.ap-northeast-2.amazonaws.com/image/employee/profile/default/default_user.png";
 
     @Transactional
-    public EmployeeDetailDto create(EmployeeCreateDto dto) {
+    public EmployeeDetailDto create(EmployeeCreateDto dto, MultipartFile image) {
         dto.setMobile(PhoneUtils.normalize(dto.getMobile()));
         dto.setEmergencyTel(PhoneUtils.normalize(dto.getEmergencyTel()));
         validateDuplicateOnCreate(dto);
@@ -64,6 +70,10 @@ public class EmployeeService {
                     .orElseThrow(() -> new EntityNotFoundException("직급을 찾을 수 없습니다."));
         }
 
+        String initialUrl = (dto.getProfileImageUrl() != null && !dto.getProfileImageUrl().isBlank())
+                ? dto.getProfileImageUrl()
+                : DEFAULT_PROFILE_URL;
+
         Employee employee = Employee.builder()
                 .employeeNumber(dto.getEmployeeNumber())
                 .name(dto.getName())
@@ -83,19 +93,26 @@ public class EmployeeService {
                 .authorityType(dto.getAuthorityType())
                 .employmentStatus(dto.getEmploymentStatus())
                 .employmentType(dto.getEmploymentType())
-                .profileImageUrl(dto.getProfileImageUrl())
+                .profileImageUrl(initialUrl)
                 .remark(dto.getRemark())
                 .passwordHash(passwordEncoder.encode(dto.getRawPassword()))
                 .enabled(true)
                 .build();
 
         Employee saved = employeeRepository.save(employee);
+
+        if (image != null && !image.isEmpty()) {
+            String dir = "employee/profile";
+            String uploadedUrl = awsS3Uploader.uploadFile(dir, saved.getId(), image);
+            saved.changeProfileImageUrl(uploadedUrl);
+        }
+
         List<EmployeeDispatchDto> dispatchDtos = saveAllDispatches(saved, dto.getDispatches());
         return EmployeeDetailDto.fromEntity(saved, dispatchDtos);
     }
 
     @Transactional
-    public EmployeeDetailDto update(Long id, EmployeeUpdateDto dto) {
+    public EmployeeDetailDto update(Long id, EmployeeUpdateDto dto, MultipartFile image) {
         Employee target = employeeRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("직원을 찾을 수 없습니다."));
 
@@ -125,20 +142,37 @@ public class EmployeeService {
                     .orElseThrow(() -> new EntityNotFoundException("직급을 찾을 수 없습니다."));
         }
 
+        String oldUrl = target.getProfileImageUrl();
+        String newUrl = null;
+
+        if (image != null && !image.isEmpty()) {
+            String dir = "employee/profile";
+            newUrl = awsS3Uploader.uploadFile(dir, target.getId(), image);
+            dto.setProfileImageUrl(newUrl);
+        } else {
+            String keep = (dto.getProfileImageUrl() != null && !dto.getProfileImageUrl().isBlank())
+                    ? dto.getProfileImageUrl()
+                    : target.getProfileImageUrl();
+            dto.setProfileImageUrl(keep);
+        }
+
         target.updateFromDto(dto, jobGrade);
+
+        if (newUrl != null && !isDefaultImage(oldUrl) && !Objects.equals(oldUrl, newUrl)) {
+            safeDeleteOldImage(oldUrl);
+        }
 
         if (dto.getRawPassword() != null && !dto.getRawPassword().isBlank()) {
             target.changePasswordHash(passwordEncoder.encode(dto.getRawPassword()));
         }
 
-        // 기존 배치 전량 삭제 후 재저장
         dispatchStatusRepository.deleteByEmployee(target);
         List<EmployeeDispatchDto> dispatchDtos = saveAllDispatches(target, dto.getDispatches());
         return EmployeeDetailDto.fromEntity(target, dispatchDtos);
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void deactivate(Long id) {
         Employee target = employeeRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("직원을 찾을 수 없습니다."));
 
@@ -153,11 +187,82 @@ public class EmployeeService {
             ensureTargetBelongsToMyBranches(target, actor, "삭제");
         }
 
+        target.deactivate(LocalDate.now());
+    }
+
+    @Transactional
+    public EmployeeDetailDto rehire(Long id) {
+        Employee target = employeeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("직원을 찾을 수 없습니다."));
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Claims c = (Claims) auth.getDetails();
+        String role = String.valueOf(c.get("role"));
+        Long actorId = c.get("employeeId", Long.class);
+
+        if (!"HQ_ADMIN".equals(role)) {
+            Employee actor = employeeRepository.findById(actorId)
+                    .orElseThrow(() -> new EntityNotFoundException("권한을 확인할 수 없습니다."));
+            ensureRehirePermission(target, actor);
+        }
+
+        target.rehire(LocalDate.now());
+
+        List<DispatchStatus> actives = dispatchStatusRepository
+                .findByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqual(
+                        target, "N", LocalDate.now(), LocalDate.now()
+                );
+        List<EmployeeDispatchDto> dispatchDtos = actives.stream()
+                .map(EmployeeDispatchDto::fromEntity)
+                .toList();
+
+        return EmployeeDetailDto.fromEntity(target, dispatchDtos);
+    }
+
+    private void ensureRehirePermission(Employee target, Employee actor) {
+        LocalDate today = LocalDate.now();
+
+        List<Branch> myBranches = dispatchStatusRepository
+                .findByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqual(actor, "N", today, today)
+                .stream()
+                .map(DispatchStatus::getBranch)
+                .distinct()
+                .toList();
+
+        if (myBranches.isEmpty()) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        Optional<DispatchStatus> current = dispatchStatusRepository
+                .findFirstByEmployeeAndPlacementYnAndAssignedFromLessThanEqualAndAssignedToGreaterThanEqualOrderByAssignedFromDesc(
+                        target, "N", today, today
+                );
+
+        Branch baseBranch = current
+                .map(DispatchStatus::getBranch)
+                .orElseGet(() -> {
+                    List<DispatchStatus> history = dispatchStatusRepository.findAllByEmployeeOrderByAssignedFromDesc(target);
+                    return history.isEmpty() ? null : history.get(0).getBranch();
+                });
+
+        if (baseBranch == null) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        Set<Long> allowed = myBranches.stream().map(Branch::getId).collect(Collectors.toSet());
+        if (!allowed.contains(baseBranch.getId())) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+    }
+
+    private boolean isDefaultImage(String url) {
+        return url != null && url.equals(DEFAULT_PROFILE_URL);
+    }
+
+    private void safeDeleteOldImage(String url) {
         try {
-            employeeRepository.delete(target);
-            employeeRepository.flush();
-        } catch (DataIntegrityViolationException ex) {
-            throw new EntityExistsException("해당 직원과 연관된 배치/근태/기록이 있어 삭제할 수 없습니다.");
+            awsS3Uploader.deleteByUrl(url);
+        } catch (Exception e) {
         }
     }
 
@@ -215,7 +320,7 @@ public class EmployeeService {
             validateDispatchDates(d.getAssignedFrom(), d.getAssignedTo());
 
             Branch branch = branchRepository.findById(d.getBranchId())
-                    .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("지점을 찾을 수 없습니다."));
+                    .orElseThrow(() -> new EntityNotFoundException("지점을 찾을 수 없습니다."));
 
             String placementYn = (d.getPlacementYn() == null || d.getPlacementYn().isBlank()) ? "N" : d.getPlacementYn();
 

--- a/branch/src/main/resources/application-local.yml
+++ b/branch/src/main/resources/application-local.yml
@@ -42,20 +42,20 @@ spring:
 cloud:
   aws:
     credentials:
-      access-key: xxxxxxxxxxxxx
-      secret-key: yyyyyyyyyyyyyy
+      access-key: ${ACCESS_KEY}
+      secret-key: ${SECRET_KEY}
     region:
       static: ap-northeast-2
     s3:
-      bucket: xxxxxxxxxxxxx
+      bucket: ${S3_BUCKET}
 
 jwt:
   accessTokenExpiryMinutes: 30 # 30분
-  secretKeyAt: ${accessToken}
+  secretKeyAt: ${ACCESS_TOKEN}
   #  refreshTokenExpiryDays: 180 # 180일
   refreshTokenExpiryDaysPersistent: 180 # 180일 (자동 로그인 O)
   refreshTokenExpiryDaysNonPersistent: 1 # 1일 (자동 로그인 X)
-  secretKeyRt: ${refreshToken}
+  secretKeyRt: ${REFRESH_KEY}
 
 security:
   csrf:
@@ -63,7 +63,7 @@ security:
       - "http://localhost:3000"
     skip-paths:
       - "/health"
-      -
+
 logging:
   level:
     root: info

--- a/branch/src/main/resources/application-local.yml
+++ b/branch/src/main/resources/application-local.yml
@@ -55,7 +55,7 @@ jwt:
   #  refreshTokenExpiryDays: 180 # 180일
   refreshTokenExpiryDaysPersistent: 180 # 180일 (자동 로그인 O)
   refreshTokenExpiryDaysNonPersistent: 1 # 1일 (자동 로그인 X)
-  secretKeyRt: ${REFRESH_KEY}
+  secretKeyRt: ${REFRESH_TOKEN}
 
 security:
   csrf:

--- a/branch/src/main/resources/application-local.yml
+++ b/branch/src/main/resources/application-local.yml
@@ -1,4 +1,3 @@
-
 server:
   port: 8081
 
@@ -43,6 +42,7 @@ spring:
     port: 587
     username: ${MAIL_USER}
     password: ${MAIL_PW}
+    from: no-reply@careup.com
     properties:
       mail:
         smtp:
@@ -60,7 +60,7 @@ cloud:
       bucket: ${S3_BUCKET}
 
 jwt:
-  accessTokenExpiryMinutes: 1   # ← 테스트용: 1분
+  accessTokenExpiryMinutes: 1   # 테스트용: 1분
   refreshTokenExpiryDaysPersistent: 180
   refreshTokenExpiryDaysNonPersistent: 1
   secretKeyAt: ${ACCESS_TOKEN}
@@ -73,7 +73,10 @@ security:
     skip-paths:
       - "/health"
 
+careup:
+  mail:
+    reset-base-url: "http://localhost:3000/reset-password"  # 비밀번호 재설정 링크 프론트 URL
+
 logging:
   level:
     root: info
-

--- a/branch/src/main/resources/application-local.yml
+++ b/branch/src/main/resources/application-local.yml
@@ -38,6 +38,16 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: test-topic-group-01
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USER}
+    password: ${MAIL_PW}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls.enable: true
 
 cloud:
   aws:
@@ -50,11 +60,10 @@ cloud:
       bucket: ${S3_BUCKET}
 
 jwt:
-  accessTokenExpiryMinutes: 30 # 30분
+  accessTokenExpiryMinutes: 1   # ← 테스트용: 1분
+  refreshTokenExpiryDaysPersistent: 180
+  refreshTokenExpiryDaysNonPersistent: 1
   secretKeyAt: ${ACCESS_TOKEN}
-  #  refreshTokenExpiryDays: 180 # 180일
-  refreshTokenExpiryDaysPersistent: 180 # 180일 (자동 로그인 O)
-  refreshTokenExpiryDaysNonPersistent: 1 # 1일 (자동 로그인 X)
   secretKeyRt: ${REFRESH_TOKEN}
 
 security:

--- a/branch/src/main/resources/application-prod.yml
+++ b/branch/src/main/resources/application-prod.yml
@@ -42,20 +42,20 @@ spring:
 cloud:
   aws:
     credentials:
-      access-key: xxxxxxxxxxxxx
-      secret-key: yyyyyyyyyyyyyy
+      access-key: ${ACCESS_KEY}
+      secret-key: ${SECRET_KEY}
     region:
       static: ap-northeast-2
     s3:
-      bucket: xxxxxxxxxxxxx
+      bucket: ${S3_BUCKET}
 
 jwt:
   accessTokenExpiryMinutes: 30 # 30분
-  secretKeyAt: ${accessToken}
+  secretKeyAt: ${ACCESS_TOKEN}
   #  refreshTokenExpiryDays: 180 # 180일
   refreshTokenExpiryDaysPersistent: 180 # 180일 (자동 로그인 O)
   refreshTokenExpiryDaysNonPersistent: 1 # 1일 (자동 로그인 X)
-  secretKeyRt: ${refreshToken}
+  secretKeyRt: ${REFRESH_KEY}
 
 security:
   csrf:


### PR DESCRIPTION
## 🏫 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🏫 반영 브랜치
feat/mypage-and-logout → develop

## 🏫 변경 사항
- 직원용 인증 기능 전반 구현
  - 로그인: JWT AT/RT 발급
  - 회원가입: 직원 기본 프로필/권한 세팅
  - 비밀번호 초기화(발급): 임시 비밀번호 발급/메일 전송 - 링크 클릭 시 임의 비밀번호 발급 되는 부분은 프론트 개발과 함께 진행 예정
  - 자동 로그인 유지: RT 기반 AT 재발급
  - 로그아웃: RT 무효화

## 🏫 테스트 결과
- Local/Postman 시나리오 전부 성공
  - 로그인 성공 시 200 + AT/RT 반환
  - 회원가입 성공 시 201 + 생성된 직원 요약 정보
  - 비밀번호 초기화 요청 시 200 + 메일 발송 확인
  - AT 만료 후 `POST /auth/refresh`로 200 + 신규 AT 발급 확인
  - 로그아웃 시 200 + RT 삭제(재발급 불가) 확인